### PR TITLE
Add dormant MCP server implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ Example Warp configuration snippet:
 
 Warp Preview access is required to use MCP servers. See [MCP Guide for Warp Terminal Agents](./MCP%20Guide%20for%20Warp%20Terminal%20Agents.md) and the in-depth [Warp Agent Technical Analysis](./Warp%20Agent%20Technical%20Analysis.md) for complete setup and architecture details.
 
+### Dormant MCP Server (Node.js)
+
+A minimal Node-based MCP server is available under `src/server`. It starts in a dormant state and activates when it receives `SIGUSR1` or any connection on port `9100`. The server shuts down after 5 minutes of inactivity and logs CPU and memory usage every 10 seconds.
+
+To build and start the server:
+
+```bash
+npm install
+npm run build
+node dist/server/index.js
+```
+
+For development mode, run:
+
+```bash
+npx ts-node src/server/index.ts
+```
+
+
 ## Command Line Interface
 
 The `agent-memory-server` provides a comprehensive CLI for managing servers and tasks. Key commands include starting API/MCP servers, scheduling background tasks, running workers, and managing migrations.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "agent-memory-dormant-server",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server/index.js",
+    "dev": "ts-node src/server/index.ts"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "ts-node": "^10.9.1",
+    "@types/node": "^20.11.6"
+  }
+}

--- a/src/server/DormantMCPServer.ts
+++ b/src/server/DormantMCPServer.ts
@@ -1,0 +1,106 @@
+export interface DormantMCPServer {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  activate(): Promise<void>;
+  deactivate(): Promise<void>;
+}
+
+import { EventEmitter } from "events";
+import { createServer, Server as HttpServer, IncomingMessage, ServerResponse } from "http";
+import { createServer as createNetServer, Server as NetServer } from "net";
+import os from "os";
+
+export class DefaultDormantMCPServer extends EventEmitter implements DormantMCPServer {
+  private httpServer: HttpServer | null = null;
+  private activationServer: NetServer | null = null;
+  private active = false;
+  private shutdownTimer?: NodeJS.Timeout;
+  private monitorInterval?: NodeJS.Timeout;
+
+  constructor(
+    private readonly port: number = 9000,
+    private readonly activationPort: number = 9100,
+    private readonly inactivityMs: number = 300_000
+  ) {
+    super();
+  }
+
+  async start(): Promise<void> {
+    this.httpServer = createServer(this.handleRequest.bind(this));
+    await new Promise<void>((resolve) => {
+      this.httpServer!.listen(this.port, resolve);
+    });
+
+    this.activationServer = createNetServer((socket) => {
+      socket.on("data", () => this.activate());
+    });
+    await new Promise<void>((resolve) => {
+      this.activationServer!.listen(this.activationPort, resolve);
+    });
+
+    process.on("SIGUSR1", () => this.activate());
+    process.on("SIGINT", () => this.stop());
+    process.on("SIGTERM", () => this.stop());
+
+    this.startResourceMonitor();
+    this.scheduleShutdown();
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse) {
+    this.activate();
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok" }));
+  }
+
+  async activate(): Promise<void> {
+    if (this.active) {
+      this.scheduleShutdown();
+      return;
+    }
+    this.active = true;
+    this.emit("activated");
+    this.scheduleShutdown();
+  }
+
+  async deactivate(): Promise<void> {
+    if (!this.active) return;
+    this.active = false;
+    this.emit("deactivated");
+  }
+
+  private scheduleShutdown() {
+    if (this.shutdownTimer) clearTimeout(this.shutdownTimer);
+    this.shutdownTimer = setTimeout(() => {
+      this.deactivate();
+      this.stop();
+    }, this.inactivityMs);
+  }
+
+  async stop(): Promise<void> {
+    if (this.httpServer) {
+      await new Promise<void>((resolve) => this.httpServer!.close(() => resolve()));
+      this.httpServer = null;
+    }
+    if (this.activationServer) {
+      await new Promise<void>((resolve) => this.activationServer!.close(() => resolve()));
+      this.activationServer = null;
+    }
+    this.stopResourceMonitor();
+    this.emit("stopped");
+  }
+
+  private startResourceMonitor() {
+    this.monitorInterval = setInterval(() => {
+      const memoryMb = Math.round(process.memoryUsage().rss / 1024 / 1024);
+      const cpuLoad = os.loadavg()[0];
+      const usage = { memory_mb: memoryMb, cpu_load: cpuLoad };
+      console.error(JSON.stringify({ type: "resources", usage }));
+    }, 10000);
+  }
+
+  private stopResourceMonitor() {
+    if (this.monitorInterval) clearInterval(this.monitorInterval);
+  }
+}
+
+export default DefaultDormantMCPServer;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,1 @@
+export * from "./DormantMCPServer";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/server/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- implement DormantMCPServer in TypeScript with activation and shutdown logic
- add basic Node build configuration
- document the new dormant server usage

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68702f41efec83328df234a9db81dc90