### PR TITLE
Update OAuth QA docs for Warp

### DIFF
--- a/manual_oauth_qa/README.md
+++ b/manual_oauth_qa/README.md
@@ -1,43 +1,40 @@
 # Manual OAuth QA Testing Guide
 
-This folder contains everything needed to manually test Auth0 authentication with the Redis Memory Server on any machine.
+This folder contains everything needed to manually test OAuth authentication with the Redis Memory Server on any machine. The instructions assume you are running inside **Warp Terminal** so you can quickly execute the commands.
 
 ## 📋 Prerequisites
 
-1. **Auth0 Account**: You need an Auth0 account and tenant
+1. **OAuth Provider Account**: Create a client with any OAuth 2.0 provider
 2. **Redis Server**: Running locally or accessible
 3. **API Keys**: OpenAI and/or Anthropic API keys
 4. **Python Environment**: With all dependencies installed
 
 ## 🚀 Quick Start
 
-### Step 1: Set Up Auth0
+### Step 1: Set Up Your OAuth Provider
 
-#### 1.1 Create Auth0 Application
+#### 1.1 Create an Application
 
-1. Go to [Auth0 Dashboard](https://manage.auth0.com/)
-2. Navigate to **Applications** → **Create Application**
-3. Choose **Machine to Machine Applications**
-4. Name it: `Redis Memory Server API`
+1. Open your provider's dashboard
+2. Create a **Machine to Machine** or equivalent application
+3. Name it `Redis Memory Server API`
 
-#### 1.2 Create Auth0 API (if needed)
+#### 1.2 Create API or Resource (if needed)
 
-1. Go to **APIs** → **Create API**
-2. Name: `Redis Memory Server API`
-3. Identifier: `https://api.redis-memory-server.com` (this becomes your audience)
-4. Signing Algorithm: `RS256`
+1. Create an API or resource server
+2. Identifier: `https://api.redis-memory-server.com` (your audience)
+3. Signing Algorithm: `RS256`
 
 #### 1.3 Authorize Your Application
 
-1. In **APIs** → **Redis Memory Server API** → **Machine to Machine Applications**
-2. Find your application and toggle it **ON**
-3. Select any required scopes (or leave empty)
+1. Allow the application to access the API
+2. Select any required scopes
 
 #### 1.4 Get Credentials
 
-From your Auth0 application, note down:
+From your provider's dashboard, note down:
 
-- **Domain**: `your-domain.auth0.com`
+- **Domain**: e.g. `your-oauth-provider.com`
 - **Client ID**: Found in application settings
 - **Client Secret**: Found in application settings
 - **Audience**: Your API identifier
@@ -52,18 +49,18 @@ Copy the `env_template` to `.env` and update with your values:
 cp manual_oauth_qa/env_template .env
 ```
 
-#### 2.2 Update .env with Your Auth0 Values
+#### 2.2 Update .env with Your OAuth Values
 
 ```bash
-# Authentication Configuration (Auth0)
+# Authentication Configuration
 DISABLE_AUTH=false
-OAUTH2_ISSUER_URL=https://your-domain.auth0.com/
+OAUTH2_ISSUER_URL=https://your-oauth-provider.com/
 OAUTH2_AUDIENCE=https://api.redis-memory-server.com
 OAUTH2_ALGORITHMS=["RS256"]
 
-# Auth0 Client Credentials (for testing script)
-AUTH0_CLIENT_ID=your-client-id
-AUTH0_CLIENT_SECRET=your-client-secret
+# OAuth Client Credentials (for testing script)
+OAUTH_CLIENT_ID=your-client-id
+OAUTH_CLIENT_SECRET=your-client-secret
 
 # Your API Keys
 OPENAI_API_KEY=your-actual-openai-key
@@ -103,12 +100,12 @@ You should see logs indicating:
 
 ```bash
 # Run the comprehensive test script
-uv run python manual_oauth_qa/test_auth0.py
+uv run python manual_oauth_qa/test_oauth.py
 ```
 
 This will:
 
-1. Get an Auth0 access token
+1. Get an OAuth access token
 2. Test all authenticated endpoints
 3. Verify authentication rejection works
 4. Provide a detailed report
@@ -117,10 +114,10 @@ This will:
 
 - **`README.md`** - This comprehensive guide
 - **`env_template`** - Environment variable template
-- **`test_auth0.py`** - Comprehensive Auth0 test script
+- **`test_oauth.py`** - Comprehensive OAuth test script
 - **`setup_check.py`** - Pre-flight checks for dependencies
-- **`debug_auth0.py`** - Debug script for troubleshooting
-- **`quick_auth0_setup.sh`** - Automated setup script
+- **`debug_oauth.py`** - Debug script for troubleshooting
+- **`quick_oauth_setup.sh`** - Automated setup script
 - **`TROUBLESHOOTING.md`** - Detailed troubleshooting guide
 
 ## 🧪 Manual Testing Methods
@@ -129,27 +126,27 @@ This will:
 
 ```bash
 # Run the comprehensive test script
-uv run python manual_oauth_qa/test_auth0.py
+uv run python manual_oauth_qa/test_oauth.py
 ```
 
 ### Method 2: Manual cURL Testing
 
-#### Get Auth0 Token
+#### Get OAuth Token
 
 ```bash
-# Set your Auth0 credentials
-export AUTH0_DOMAIN="your-domain.auth0.com"
-export AUTH0_CLIENT_ID="your-client-id"
-export AUTH0_CLIENT_SECRET="your-client-secret"
-export AUTH0_AUDIENCE="https://api.redis-memory-server.com"
+# Set your OAuth credentials
+export OAUTH_DOMAIN="your-oauth-provider.com"
+export OAUTH_CLIENT_ID="your-client-id"
+export OAUTH_CLIENT_SECRET="your-client-secret"
+export OAUTH_AUDIENCE="https://api.redis-memory-server.com"
 
 # Get access token
-TOKEN=$(curl -s -X POST "https://$AUTH0_DOMAIN/oauth/token" \
+TOKEN=$(curl -s -X POST "https://$OAUTH_DOMAIN/oauth/token" \
   -H "Content-Type: application/json" \
   -d '{
-    "client_id": "'$AUTH0_CLIENT_ID'",
-    "client_secret": "'$AUTH0_CLIENT_SECRET'",
-    "audience": "'$AUTH0_AUDIENCE'",
+    "client_id": "'$OAUTH_CLIENT_ID'",
+    "client_secret": "'$OAUTH_CLIENT_SECRET'",
+    "audience": "'$OAUTH_AUDIENCE'",
     "grant_type": "client_credentials"
   }' | jq -r '.access_token')
 
@@ -178,7 +175,7 @@ curl -X POST \
      -d '{
        "memories": [
          {
-           "text": "Auth0 test memory",
+          "text": "OAuth test memory",
            "session_id": "test-session",
            "namespace": "test"
          }
@@ -190,7 +187,7 @@ curl -X POST \
 curl -X POST \
      -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: application/json" \
-     -d '{"text": "Auth0 test", "limit": 5}' \
+     -d '{"text": "OAuth test", "limit": 5}' \
      http://localhost:8000/v1/long-term-memory/search
 ```
 
@@ -213,9 +210,9 @@ curl -H "Authorization: Bearer invalid.jwt.token" \
 import requests
 import json
 
-# Get Auth0 token
-def get_auth0_token():
-    token_url = "https://your-domain.auth0.com/oauth/token"
+# Get OAuth token
+def get_oauth_token():
+    token_url = "https://your-oauth-provider.com/oauth/token"
     payload = {
         "client_id": "your-client-id",
         "client_secret": "your-client-secret",
@@ -228,7 +225,7 @@ def get_auth0_token():
     return response.json()["access_token"]
 
 # Test authenticated endpoint
-token = get_auth0_token()
+token = get_oauth_token()
 headers = {
     "Authorization": f"Bearer {token}",
     "Content-Type": "application/json"
@@ -246,15 +243,15 @@ print(f"Response: {response.json()}")
 - [ ] **Health endpoint works without auth**: `GET /v1/health` returns 200
 - [ ] **Authenticated endpoints require token**: Return 401 without `Authorization` header
 - [ ] **Invalid tokens rejected**: Return 401 with malformed or expired tokens
-- [ ] **Valid tokens accepted**: Return 200/201 with proper Auth0 JWT tokens
-- [ ] **JWKS validation works**: Server fetches and caches Auth0 public keys
+- [ ] **Valid tokens accepted**: Return 200/201 with proper JWT tokens
+- [ ] **JWKS validation works**: Server fetches and caches provider public keys
 - [ ] **Token claims extracted**: User info extracted from JWT payload
 
-### Auth0-Specific Validations
+### Provider-Specific Validations
 
 - [ ] **Issuer validation**: Token `iss` claim matches `OAUTH2_ISSUER_URL`
 - [ ] **Audience validation**: Token `aud` claim matches `OAUTH2_AUDIENCE`
-- [ ] **Signature validation**: Token signature verified using Auth0 JWKS
+- [ ] **Signature validation**: Token signature verified using provider JWKS
 - [ ] **Expiration validation**: Expired tokens rejected
 - [ ] **Algorithm validation**: Only RS256 tokens accepted
 
@@ -263,7 +260,7 @@ print(f"Response: {response.json()}")
 When everything is working correctly, you should see:
 
 ```
-🎉 All Auth0 authentication tests passed!
+🎉 All OAuth authentication tests passed!
 📊 Test Summary
 Authenticated endpoints: 4/4 passed
 Health endpoint: ✅
@@ -283,24 +280,24 @@ Invalid token rejection: ✅
 #### "Unable to fetch JWKS"
 
 - Check internet connectivity
-- Verify Auth0 domain is correct
-- Check if Auth0 service is accessible
+- Verify provider domain is correct
+- Check if the OAuth service is accessible
 
 #### "Invalid audience"
 
-- Verify `OAUTH2_AUDIENCE` matches your Auth0 API identifier
-- Check Auth0 application is authorized for the API
+- Verify `OAUTH2_AUDIENCE` matches your API identifier
+- Check your application is authorized for the API
 
 #### "Unable to find matching public key"
 
-- Token `kid` doesn't match any key in Auth0 JWKS
+- Token `kid` doesn't match any key in provider JWKS
 - Try regenerating the token
-- Check Auth0 key rotation settings
+- Check provider key rotation settings
 
 #### "Token has expired"
 
-- Auth0 tokens have limited lifetime (usually 24 hours)
-- Get a fresh token from Auth0
+- Provider tokens have limited lifetime (usually 24 hours)
+- Get a fresh token from your provider
 
 #### Environment Variables Not Loading
 
@@ -310,9 +307,9 @@ Invalid token rejection: ✅
 
 ### Debug Steps
 
-1. **Check configuration**: `python debug_auth0.py`
+1. **Check configuration**: `python debug_oauth.py`
 2. **Verify dependencies**: `python setup_check.py`
-3. **Test Auth0 directly**: Use the cURL commands above
+3. **Test the OAuth flow directly**: Use the cURL commands above
 4. **Check server logs**: Look for authentication configuration messages
 
 #### Debug Mode
@@ -333,9 +330,9 @@ This will show:
 ## 🔒 Security Notes
 
 - Never commit your `.env` file to version control
-- Use different Auth0 applications for development and production
+- Use different OAuth applications for development and production
 - Rotate client secrets regularly
-- Monitor Auth0 logs for suspicious activity
+- Monitor authentication logs for suspicious activity
 
 ### Production Considerations
 
@@ -343,14 +340,14 @@ This will show:
 
 - [ ] **HTTPS Only**: Use HTTPS in production
 - [ ] **Token Refresh**: Implement token refresh in clients
-- [ ] **Rate Limiting**: Consider rate limiting on Auth0 token endpoint
+- [ ] **Rate Limiting**: Consider rate limiting on the token endpoint
 - [ ] **Monitoring**: Monitor authentication failures
-- [ ] **Key Rotation**: Handle Auth0 key rotation gracefully
+- [ ] **Key Rotation**: Handle provider key rotation gracefully
 
 #### Performance Considerations
 
 - [ ] **JWKS Caching**: Verify JWKS keys are cached (default 1 hour)
-- [ ] **Connection Pooling**: Use connection pooling for Auth0 requests
+- [ ] **Connection Pooling**: Use connection pooling for provider requests
 - [ ] **Token Validation**: JWT validation is CPU-intensive, consider caching
 
 ## 📞 Support
@@ -358,18 +355,16 @@ This will show:
 If you encounter issues:
 
 1. Check the troubleshooting section above
-2. Run the debug script: `python debug_auth0.py`
-3. Verify your Auth0 configuration in the dashboard
+2. Run the debug script: `python debug_oauth.py`
+3. Verify your provider configuration in the dashboard
 4. Check that all environment variables are set correctly
 5. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for detailed debugging
 
 ### Support Resources
 
-- [Auth0 Documentation](https://auth0.com/docs)
-- [Auth0 Community](https://community.auth0.com/)
-- [Auth0 Support](https://support.auth0.com/)
+- [OAuth 2.0 Spec](https://oauth.net/2/)
 - [JWT.io](https://jwt.io/) - For debugging JWT tokens
 
 ---
 
-This guide provides comprehensive manual testing for Auth0 authentication. The automated test script (`test_auth0.py`) is the quickest way to verify everything works, while manual cURL/Python testing gives you more control and understanding of the authentication flow.
+This guide provides comprehensive manual testing for generic OAuth authentication. The automated test script (`test_oauth.py`) is the quickest way to verify everything works, while manual cURL/Python testing gives you more control and understanding of the authentication flow.

--- a/manual_oauth_qa/debug_oauth.py
+++ b/manual_oauth_qa/debug_oauth.py
@@ -7,31 +7,31 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-AUTH0_DOMAIN = (
+OAUTH_DOMAIN = (
     os.getenv("OAUTH2_ISSUER_URL", "").replace("https://", "").replace("/", "")
 )
-AUTH0_CLIENT_ID = os.getenv("AUTH0_CLIENT_ID")
-AUTH0_CLIENT_SECRET = os.getenv("AUTH0_CLIENT_SECRET")
-AUTH0_AUDIENCE = os.getenv("OAUTH2_AUDIENCE")
+OAUTH_CLIENT_ID = os.getenv("OAUTH_CLIENT_ID")
+OAUTH_CLIENT_SECRET = os.getenv("OAUTH_CLIENT_SECRET")
+OAUTH_AUDIENCE = os.getenv("OAUTH2_AUDIENCE")
 
-print("=== Auth0 Configuration Debug ===")
-print(f"Domain: {AUTH0_DOMAIN}")
-print(f"Client ID: {AUTH0_CLIENT_ID}")
+print("=== OAuth Configuration Debug ===")
+print(f"Domain: {OAUTH_DOMAIN}")
+print(f"Client ID: {OAUTH_CLIENT_ID}")
 print(
-    f"Client Secret: {AUTH0_CLIENT_SECRET[:10]}..." if AUTH0_CLIENT_SECRET else "None"
+    f"Client Secret: {OAUTH_CLIENT_SECRET[:10]}..." if OAUTH_CLIENT_SECRET else "None"
 )
-print(f"Audience: {AUTH0_AUDIENCE}")
-print(f"Token URL: https://{AUTH0_DOMAIN}/oauth/token")
+print(f"Audience: {OAUTH_AUDIENCE}")
+print(f"Token URL: https://{OAUTH_DOMAIN}/oauth/token")
 
 print("\n=== Validation ===")
 missing = []
-if not AUTH0_DOMAIN:
+if not OAUTH_DOMAIN:
     missing.append("OAUTH2_ISSUER_URL")
-if not AUTH0_CLIENT_ID:
-    missing.append("AUTH0_CLIENT_ID")
-if not AUTH0_CLIENT_SECRET:
-    missing.append("AUTH0_CLIENT_SECRET")
-if not AUTH0_AUDIENCE:
+if not OAUTH_CLIENT_ID:
+    missing.append("OAUTH_CLIENT_ID")
+if not OAUTH_CLIENT_SECRET:
+    missing.append("OAUTH_CLIENT_SECRET")
+if not OAUTH_AUDIENCE:
     missing.append("OAUTH2_AUDIENCE")
 
 if missing:
@@ -40,12 +40,12 @@ if missing:
 else:
     print("✅ All required values present")
 
-print("\n=== Testing Auth0 Token Request ===")
-token_url = f"https://{AUTH0_DOMAIN}/oauth/token"
+print("\n=== Testing OAuth Token Request ===")
+token_url = f"https://{OAUTH_DOMAIN}/oauth/token"
 payload = {
-    "client_id": AUTH0_CLIENT_ID,
-    "client_secret": AUTH0_CLIENT_SECRET,
-    "audience": AUTH0_AUDIENCE,
+    "client_id": OAUTH_CLIENT_ID,
+    "client_secret": OAUTH_CLIENT_SECRET,
+    "audience": OAUTH_AUDIENCE,
     "grant_type": "client_credentials",
 }
 
@@ -61,9 +61,9 @@ try:
         print(f"Response: {response.text}")
 
         if response.status_code == 200:
-            print("✅ Auth0 token request successful!")
+            print("✅ OAuth token request successful!")
         else:
-            print("❌ Auth0 token request failed!")
+            print("❌ OAuth token request failed!")
 
 except Exception as e:
     print(f"❌ Exception during token request: {e}")

--- a/manual_oauth_qa/env_template
+++ b/manual_oauth_qa/env_template
@@ -1,21 +1,21 @@
-# Auth0 Manual Testing Configuration Template
+# OAuth Manual Testing Configuration Template
 # Copy this file to .env and update with your actual values
 
 # Redis Configuration
 REDIS_URL=redis://localhost:6379
 
-# Authentication Configuration (Auth0)
+# Authentication Configuration
 DISABLE_AUTH=false
-OAUTH2_ISSUER_URL=https://your-domain.auth0.com/
+OAUTH2_ISSUER_URL=https://your-oauth-provider.com/
 OAUTH2_AUDIENCE=https://api.redis-memory-server.com
 OAUTH2_ALGORITHMS=["RS256"]
 
-# Auth0 Client Credentials (get these from Auth0 Dashboard)
-AUTH0_CLIENT_ID=your-auth0-client-id
-AUTH0_CLIENT_SECRET=your-auth0-client-secret
+# OAuth Client Credentials (get these from your provider)
+OAUTH_CLIENT_ID=your-client-id
+OAUTH_CLIENT_SECRET=your-client-secret
 
 # Optional: Explicit JWKS URL (auto-derived from issuer if not set)
-# OAUTH2_JWKS_URL=https://your-domain.auth0.com/.well-known/jwks.json
+# OAUTH2_JWKS_URL=https://your-oauth-provider.com/.well-known/jwks.json
 
 # AI Service API Keys
 OPENAI_API_KEY=your-openai-api-key-here

--- a/manual_oauth_qa/quick_oauth_setup.sh
+++ b/manual_oauth_qa/quick_oauth_setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Quick Auth0 Setup Script for Redis Memory Server
-# This script helps you quickly set up and test Auth0 authentication
+# Quick OAuth Setup Script for Redis Memory Server
+# This script helps you quickly set up and test OAuth authentication
 
 set -e
 
-echo "🔮 Redis Memory Server - Auth0 Quick Setup"
+echo "🔮 Redis Memory Server - OAuth Quick Setup"
 echo "=========================================="
 
 # Check if .env exists
@@ -15,10 +15,10 @@ if [ ! -f .env ]; then
     echo "✅ Created .env file"
     echo ""
     echo "⚠️  IMPORTANT: Please edit .env and update the following values:"
-    echo "   - OAUTH2_ISSUER_URL (your Auth0 domain)"
-    echo "   - OAUTH2_AUDIENCE (your Auth0 API identifier)"
-    echo "   - AUTH0_CLIENT_ID (your Auth0 application client ID)"
-    echo "   - AUTH0_CLIENT_SECRET (your Auth0 application client secret)"
+    echo "   - OAUTH2_ISSUER_URL (issuer URL from your provider)"
+    echo "   - OAUTH2_AUDIENCE (API identifier)"
+    echo "   - OAUTH_CLIENT_ID (client ID)"
+    echo "   - OAUTH_CLIENT_SECRET (client secret)"
     echo "   - OPENAI_API_KEY (your OpenAI API key)"
     echo "   - ANTHROPIC_API_KEY (your Anthropic API key)"
     echo ""
@@ -47,7 +47,7 @@ else
 fi
 
 # Check environment variables
-echo "🔍 Checking Auth0 configuration..."
+echo "🔍 Checking OAuth configuration..."
 source .env
 
 if [ -z "$OAUTH2_ISSUER_URL" ] || [ "$OAUTH2_ISSUER_URL" = "https://your-domain.auth0.com/" ]; then
@@ -60,35 +60,35 @@ if [ -z "$OAUTH2_AUDIENCE" ] || [ "$OAUTH2_AUDIENCE" = "https://api.your-app.com
     exit 1
 fi
 
-if [ -z "$AUTH0_CLIENT_ID" ] || [ "$AUTH0_CLIENT_ID" = "your-client-id" ]; then
-    echo "❌ AUTH0_CLIENT_ID not configured in .env"
+if [ -z "$OAUTH_CLIENT_ID" ] || [ "$OAUTH_CLIENT_ID" = "your-client-id" ]; then
+    echo "❌ OAUTH_CLIENT_ID not configured in .env"
     exit 1
 fi
 
-if [ -z "$AUTH0_CLIENT_SECRET" ] || [ "$AUTH0_CLIENT_SECRET" = "your-client-secret" ]; then
-    echo "❌ AUTH0_CLIENT_SECRET not configured in .env"
+if [ -z "$OAUTH_CLIENT_SECRET" ] || [ "$OAUTH_CLIENT_SECRET" = "your-client-secret" ]; then
+    echo "❌ OAUTH_CLIENT_SECRET not configured in .env"
     exit 1
 fi
 
-echo "✅ Auth0 configuration looks good"
+echo "✅ OAuth configuration looks good"
 
-# Test Auth0 token endpoint
-echo "🔍 Testing Auth0 token endpoint..."
-AUTH0_DOMAIN=$(echo $OAUTH2_ISSUER_URL | sed 's|https://||' | sed 's|/||')
+# Test OAuth token endpoint
+echo "🔍 Testing OAuth token endpoint..."
+OAUTH_DOMAIN=$(echo $OAUTH2_ISSUER_URL | sed 's|https://||' | sed 's|/||')
 
-TOKEN_RESPONSE=$(curl -s -X POST "https://$AUTH0_DOMAIN/oauth/token" \
+TOKEN_RESPONSE=$(curl -s -X POST "https://$OAUTH_DOMAIN/oauth/token" \
   -H "Content-Type: application/json" \
   -d "{
-    \"client_id\": \"$AUTH0_CLIENT_ID\",
-    \"client_secret\": \"$AUTH0_CLIENT_SECRET\",
+  \"client_id\": \"$OAUTH_CLIENT_ID\",
+  \"client_secret\": \"$OAUTH_CLIENT_SECRET\",
     \"audience\": \"$OAUTH2_AUDIENCE\",
     \"grant_type\": \"client_credentials\"
   }")
 
 if echo "$TOKEN_RESPONSE" | grep -q "access_token"; then
-    echo "✅ Successfully obtained Auth0 token"
+    echo "✅ Successfully obtained OAuth token"
 else
-    echo "❌ Failed to get Auth0 token:"
+    echo "❌ Failed to get OAuth token:"
     echo "$TOKEN_RESPONSE"
     exit 1
 fi
@@ -99,8 +99,8 @@ echo ""
 echo "1. Start the memory server:"
 echo "   uv run python -m agent_memory_server.main"
 echo ""
-echo "2. Run the automated Auth0 test:"
-echo "   uv run python manual_oauth_qa/manual_auth0_test.py"
+echo "2. Run the automated OAuth test:"
+echo "   uv run python manual_oauth_qa/manual_oauth_test.py"
 echo ""
 echo "3. Or follow the manual testing guide:"
 echo "   cat manual_oauth_qa/README.md"

--- a/manual_oauth_qa/quick_setup.sh
+++ b/manual_oauth_qa/quick_setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Quick Auth0 Setup Script for Redis Memory Server
-# This script helps you quickly set up and test Auth0 authentication
+# Quick OAuth Setup Script for Redis Memory Server
+# This script helps you quickly set up and test OAuth authentication
 
 set -e
 
-echo "🔮 Redis Memory Server - Auth0 Quick Setup"
+echo "🔮 Redis Memory Server - OAuth Quick Setup"
 echo "=========================================="
 
 # Check if we're in the right directory
@@ -21,10 +21,10 @@ if [ ! -f .env ]; then
     echo "✅ Created .env file"
     echo ""
     echo "⚠️  IMPORTANT: Please edit .env and update the following values:"
-    echo "   - OAUTH2_ISSUER_URL (your Auth0 domain)"
-    echo "   - OAUTH2_AUDIENCE (your Auth0 API identifier)"
-    echo "   - AUTH0_CLIENT_ID (your Auth0 application client ID)"
-    echo "   - AUTH0_CLIENT_SECRET (your Auth0 application client secret)"
+    echo "   - OAUTH2_ISSUER_URL (issuer URL from your provider)"
+    echo "   - OAUTH2_AUDIENCE (API identifier)"
+    echo "   - OAUTH_CLIENT_ID (client ID)"
+    echo "   - OAUTH_CLIENT_SECRET (client secret)"
     echo "   - OPENAI_API_KEY (your OpenAI API key)"
     echo "   - ANTHROPIC_API_KEY (your Anthropic API key)"
     echo ""
@@ -46,8 +46,8 @@ else
     exit 1
 fi
 
-# Check Auth0 configuration
-echo "🔍 Checking Auth0 configuration..."
+# Check OAuth configuration
+echo "🔍 Checking OAuth configuration..."
 source .env
 
 if [[ -z "$OAUTH2_ISSUER_URL" || "$OAUTH2_ISSUER_URL" == "https://your-domain.auth0.com/" ]]; then
@@ -60,34 +60,34 @@ if [[ -z "$OAUTH2_AUDIENCE" || "$OAUTH2_AUDIENCE" == "https://api.redis-memory-s
     exit 1
 fi
 
-if [[ -z "$AUTH0_CLIENT_ID" || "$AUTH0_CLIENT_ID" == "your-auth0-client-id" ]]; then
-    echo "❌ AUTH0_CLIENT_ID not configured in .env"
+if [[ -z "$OAUTH_CLIENT_ID" || "$OAUTH_CLIENT_ID" == "your-client-id" ]]; then
+    echo "❌ OAUTH_CLIENT_ID not configured in .env"
     exit 1
 fi
 
-if [[ -z "$AUTH0_CLIENT_SECRET" || "$AUTH0_CLIENT_SECRET" == "your-auth0-client-secret" ]]; then
-    echo "❌ AUTH0_CLIENT_SECRET not configured in .env"
+if [[ -z "$OAUTH_CLIENT_SECRET" || "$OAUTH_CLIENT_SECRET" == "your-client-secret" ]]; then
+    echo "❌ OAUTH_CLIENT_SECRET not configured in .env"
     exit 1
 fi
 
-echo "✅ Auth0 configuration looks good"
+echo "✅ OAuth configuration looks good"
 
-# Test Auth0 token endpoint
-echo "🔍 Testing Auth0 token endpoint..."
+# Test OAuth token endpoint
+echo "🔍 Testing OAuth token endpoint..."
 DOMAIN=$(echo $OAUTH2_ISSUER_URL | sed 's|https://||' | sed 's|/$||')
 TOKEN_RESPONSE=$(curl -s -X POST "https://$DOMAIN/oauth/token" \
     -H "Content-Type: application/json" \
     -d "{
-    \"client_id\": \"$AUTH0_CLIENT_ID\",
-    \"client_secret\": \"$AUTH0_CLIENT_SECRET\",
+    \"client_id\": \"$OAUTH_CLIENT_ID\",
+    \"client_secret\": \"$OAUTH_CLIENT_SECRET\",
     \"audience\": \"$OAUTH2_AUDIENCE\",
     \"grant_type\": \"client_credentials\"
   }")
 
 if echo "$TOKEN_RESPONSE" | grep -q "access_token"; then
-    echo "✅ Successfully obtained Auth0 token"
+    echo "✅ Successfully obtained OAuth token"
 else
-    echo "❌ Failed to get Auth0 token:"
+    echo "❌ Failed to get OAuth token:"
     echo "$TOKEN_RESPONSE"
     exit 1
 fi
@@ -101,14 +101,14 @@ if curl -s "http://localhost:$PORT/v1/health" >/dev/null 2>&1; then
     echo ""
     echo "🚀 Setup complete! You can now:"
     echo ""
-    echo "1. Run the comprehensive Auth0 test:"
-    echo "   python manual_oauth_qa/test_auth0.py"
+    echo "1. Run the comprehensive OAuth test:"
+    echo "   python manual_oauth_qa/test_oauth.py"
     echo ""
     echo "2. Run setup checks:"
     echo "   python manual_oauth_qa/setup_check.py"
     echo ""
-    echo "3. Debug Auth0 configuration:"
-    echo "   python manual_oauth_qa/debug_auth0.py"
+    echo "3. Debug OAuth configuration:"
+    echo "   python manual_oauth_qa/debug_oauth.py"
     echo ""
     echo "🎉 Happy testing!"
 else
@@ -117,6 +117,6 @@ else
     echo "Start the memory server with:"
     echo "   uv run python -m agent_memory_server.main"
     echo ""
-    echo "Then run the Auth0 tests:"
-    echo "   python manual_oauth_qa/test_auth0.py"
+    echo "Then run the OAuth tests:"
+    echo "   python manual_oauth_qa/test_oauth.py"
 fi

--- a/manual_oauth_qa/setup_check.py
+++ b/manual_oauth_qa/setup_check.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Setup Check Script for Auth0 Manual Testing
+Setup Check Script for OAuth Manual Testing
 
 This script verifies that all dependencies and configuration
-are properly set up for Auth0 testing.
+are properly set up for OAuth testing.
 """
 
 import os
@@ -91,8 +91,8 @@ def check_env_file():
     required_vars = [
         "OAUTH2_ISSUER_URL",
         "OAUTH2_AUDIENCE",
-        "AUTH0_CLIENT_ID",
-        "AUTH0_CLIENT_SECRET",
+        "OAUTH_CLIENT_ID",
+        "OAUTH_CLIENT_SECRET",
     ]
 
     missing_vars = []
@@ -132,7 +132,7 @@ def check_memory_server():
 
 def main():
     """Run all checks"""
-    print("🔍 Redis Memory Server - Auth0 Setup Check")
+    print("🔍 Redis Memory Server - OAuth Setup Check")
     print("=" * 50)
 
     checks = [
@@ -149,9 +149,9 @@ def main():
     print(f"\n📊 Setup Check Results: {passed}/{total} passed")
 
     if passed == total:
-        print("🎉 All checks passed! Ready for Auth0 testing.")
+        print("🎉 All checks passed! Ready for OAuth testing.")
         print("\nNext steps:")
-        print("1. Run: python manual_oauth_qa/test_auth0.py")
+        print("1. Run: python manual_oauth_qa/test_oauth.py")
         return True
     print("❌ Some checks failed. Please fix the issues above.")
     return False

--- a/manual_oauth_qa/test_oauth.py
+++ b/manual_oauth_qa/test_oauth.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 """
-Manual Auth0 Testing Script for Redis Memory Server
+Manual OAuth Testing Script for Redis Memory Server
 
-This script helps you test Auth0 authentication with the Redis Memory Server.
+This script helps you test OAuth authentication with the Redis Memory Server.
 It will:
-1. Get an access token from Auth0
+1. Get an access token from your provider
 2. Test various API endpoints with the token
 3. Verify authentication is working correctly
 
 Prerequisites:
-1. Auth0 application configured (Machine to Machine)
-2. .env file with Auth0 configuration
+1. OAuth application configured (Machine to Machine)
+2. .env file with OAuth configuration
 3. Redis server running
 4. Memory server running with authentication enabled
 """
@@ -31,51 +31,51 @@ load_dotenv()
 # Configure logging
 logger = structlog.get_logger()
 
-# Auth0 Configuration
-AUTH0_DOMAIN = (
+# OAuth Configuration
+OAUTH_DOMAIN = (
     os.getenv("OAUTH2_ISSUER_URL", "").replace("https://", "").replace("/", "")
 )
-AUTH0_CLIENT_ID = os.getenv("AUTH0_CLIENT_ID")
-AUTH0_CLIENT_SECRET = os.getenv("AUTH0_CLIENT_SECRET")
-AUTH0_AUDIENCE = os.getenv("OAUTH2_AUDIENCE")
+OAUTH_CLIENT_ID = os.getenv("OAUTH_CLIENT_ID")
+OAUTH_CLIENT_SECRET = os.getenv("OAUTH_CLIENT_SECRET")
+OAUTH_AUDIENCE = os.getenv("OAUTH2_AUDIENCE")
 
 # Memory Server Configuration
 MEMORY_SERVER_URL = f"http://localhost:{os.getenv('PORT', '8000')}"
 
 
-class Auth0Tester:
+class OAuthTester:
     def __init__(self):
         self.access_token = None
         self.client = httpx.Client(timeout=30.0)
 
-    def get_auth0_token(self) -> str:
-        """Get an access token from Auth0"""
+    def get_oauth_token(self) -> str:
+        """Get an access token from the provider"""
         if not all(
-            [AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_AUDIENCE]
+            [OAUTH_DOMAIN, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_AUDIENCE]
         ):
             raise ValueError(
-                "Missing Auth0 configuration. Please set:\n"
-                "- OAUTH2_ISSUER_URL (e.g., https://your-domain.auth0.com/)\n"
-                "- AUTH0_CLIENT_ID\n"
-                "- AUTH0_CLIENT_SECRET\n"
+                "Missing OAuth configuration. Please set:\n"
+                "- OAUTH2_ISSUER_URL\n"
+                "- OAUTH_CLIENT_ID\n"
+                "- OAUTH_CLIENT_SECRET\n"
                 "- OAUTH2_AUDIENCE"
             )
 
-        token_url = f"https://{AUTH0_DOMAIN}/oauth/token"
+        token_url = f"https://{OAUTH_DOMAIN}/oauth/token"
 
         payload = {
-            "client_id": AUTH0_CLIENT_ID,
-            "client_secret": AUTH0_CLIENT_SECRET,
-            "audience": AUTH0_AUDIENCE,
+            "client_id": OAUTH_CLIENT_ID,
+            "client_secret": OAUTH_CLIENT_SECRET,
+            "audience": OAUTH_AUDIENCE,
             "grant_type": "client_credentials",
         }
 
         headers = {"Content-Type": "application/json"}
 
         logger.info(
-            "Requesting Auth0 access token",
-            domain=AUTH0_DOMAIN,
-            audience=AUTH0_AUDIENCE,
+            "Requesting OAuth access token",
+            domain=OAUTH_DOMAIN,
+            audience=OAUTH_AUDIENCE,
         )
 
         try:
@@ -86,7 +86,7 @@ class Auth0Tester:
             self.access_token = token_data["access_token"]
 
             logger.info(
-                "Successfully obtained Auth0 token",
+                "Successfully obtained OAuth token",
                 token_type=token_data.get("token_type"),
                 expires_in=token_data.get("expires_in"),
             )
@@ -94,9 +94,9 @@ class Auth0Tester:
             return self.access_token
 
         except httpx.HTTPError as e:
-            logger.error("Failed to get Auth0 token", error=str(e))
+            logger.error("Failed to get OAuth token", error=str(e))
             if hasattr(e, "response") and e.response:
-                logger.error("Auth0 error response", response=e.response.text)
+                logger.error("OAuth error response", response=e.response.text)
             raise
 
     def test_endpoint(
@@ -152,13 +152,13 @@ class Auth0Tester:
 
     def run_comprehensive_test(self):
         """Run a comprehensive test of all endpoints"""
-        logger.info("🚀 Starting comprehensive Auth0 authentication test")
+        logger.info("🚀 Starting comprehensive OAuth authentication test")
 
-        # Step 1: Get Auth0 token
+        # Step 1: Get OAuth token
         try:
-            self.get_auth0_token()
+            self.get_oauth_token()
         except Exception as e:
-            logger.error("Failed to get Auth0 token, aborting tests", error=str(e))
+            logger.error("Failed to get OAuth token, aborting tests", error=str(e))
             return False
 
         # Step 2: Test health endpoint (should work without auth)
@@ -178,8 +178,8 @@ class Auth0Tester:
                 {
                     "query": "What is the capital of France?",
                     "session": {
-                        "session_id": "test-session-auth0",
-                        "namespace": "test-auth0",
+                        "session_id": "test-session-oauth",
+                        "namespace": "test-oauth",
                         "window_size": 10,
                     },
                 },
@@ -190,15 +190,15 @@ class Auth0Tester:
                 {
                     "memories": [
                         {
-                            "id": "auth0-test-memory-1",
-                            "text": "Auth0 test memory",
-                            "session_id": "test-session-auth0",
-                            "namespace": "test-auth0",
+                            "id": "oauth-test-memory-1",
+                            "text": "OAuth test memory",
+                            "session_id": "test-session-oauth",
+                            "namespace": "test-oauth",
                         }
                     ]
                 },
             ),
-            ("POST", "/long-term-memory/search", {"text": "Auth0 test", "limit": 5}),
+            ("POST", "/long-term-memory/search", {"text": "OAuth test", "limit": 5}),
         ]
 
         results = []
@@ -260,21 +260,21 @@ class Auth0Tester:
         )
 
         if overall_success:
-            logger.info("🎉 All Auth0 authentication tests passed!")
+            logger.info("🎉 All OAuth authentication tests passed!")
         else:
-            logger.error("❌ Some Auth0 authentication tests failed")
+            logger.error("❌ Some OAuth authentication tests failed")
 
         return overall_success
 
 
 def main():
-    """Main function to run Auth0 tests"""
-    print("🔮 Redis Memory Server - Auth0 Manual Testing")
+    """Main function to run OAuth tests"""
+    print("🔮 Redis Memory Server - OAuth Manual Testing")
     print("=" * 50)
 
     # Check if memory server is running
     try:
-        response = httpx.get(f"{MEMORY_SERVER_URL}/health", timeout=5.0)
+        response = httpx.get(f"{MEMORY_SERVER_URL}/v1/health", timeout=5.0)
         if response.status_code != 200:
             print(f"❌ Memory server not responding correctly at {MEMORY_SERVER_URL}")
             print("Please start the memory server first:")
@@ -290,7 +290,7 @@ def main():
     print(f"✅ Memory server is running at {MEMORY_SERVER_URL}")
 
     # Run tests
-    tester = Auth0Tester()
+    tester = OAuthTester()
     success = tester.run_comprehensive_test()
 
     sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- rename Auth0 scripts to generic OAuth names
- remove provider-specific language from manual OAuth docs
- update env template with provider-neutral variables
- tweak setup scripts for OAuth

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docket')*

------
https://chatgpt.com/codex/tasks/task_e_68702f3f874483328e4734be77d03bd4