### PR TITLE
feat(server): switch print statements to logger

### DIFF
--- a/agent_memory_server/api.py
+++ b/agent_memory_server/api.py
@@ -453,7 +453,7 @@ async def search_long_term_memory(
     # Extract filter objects from the payload
     filters = payload.get_filters()
 
-    print("Long-term search filters: ", filters)
+    logger.debug("Long-term search filters", filters=filters)
 
     kwargs = {
         "distance_threshold": payload.distance_threshold,
@@ -462,7 +462,7 @@ async def search_long_term_memory(
         **filters,
     }
 
-    print("Kwargs: ", kwargs)
+    logger.debug("Search kwargs", params=kwargs)
 
     kwargs["text"] = payload.text or ""
 
@@ -568,7 +568,7 @@ async def memory_prompt(
     redis = await get_redis_conn()
     _messages = []
 
-    print("Received params: ", params)
+    logger.debug("Received message params", params=params.model_dump())
 
     if params.session:
         # Use token limit for memory prompt, fallback to message count for backward compatibility

--- a/agent_memory_server/config.py
+++ b/agent_memory_server/config.py
@@ -5,8 +5,12 @@ import yaml
 from dotenv import load_dotenv
 from pydantic_settings import BaseSettings
 
+from agent_memory_server.logging import get_logger
+
 
 load_dotenv()
+
+logger = get_logger(__name__)
 
 
 # Model configuration mapping
@@ -159,9 +163,13 @@ def get_config():
 
                     config_data = json.load(f) or {}
         except FileNotFoundError:
-            print(f"Warning: Config file {config_file} not found")
-        except Exception as e:
-            print(f"Warning: Error loading config file {config_file}: {e}")
+            logger.warning("Config file not found", config_file=config_file)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Error loading config file",
+                config_file=config_file,
+                error=str(e),
+            )
 
     # Environment variables override file config
     for key, value in os.environ.items():

--- a/agent_memory_server/main.py
+++ b/agent_memory_server/main.py
@@ -162,9 +162,10 @@ app.include_router(memory_router)
 
 def on_start_logger(port: int):
     """Log startup information"""
-    print("\n-----------------------------------")
-    print(f"🧠 Redis Agent Memory Server running on port: {port}")
-    print("-----------------------------------\n")
+    logger.info(
+        "Redis Agent Memory Server running",
+        port=port,
+    )
 
 
 # Run the application
@@ -178,17 +179,17 @@ if __name__ == "__main__":
             port_index = sys.argv.index("--port") + 1
             if port_index < len(sys.argv):
                 port = int(sys.argv[port_index])
-                print(f"Using port from command line: {port}")
+                logger.info("Using port from command line", port=port)
         except (ValueError, IndexError):
             # If conversion fails or index out of bounds, use default
-            print(f"Invalid port argument, using default: {port}")
+            logger.warning("Invalid port argument, using default", port=port)
     else:
-        print(f"No port argument provided, using default: {port}")
+        logger.info("No port argument provided, using default", port=port)
 
     # Explicitly unset the PORT environment variable if it exists
     if "PORT" in os.environ:
         port_val = os.environ.pop("PORT")
-        print(f"Removed environment variable PORT={port_val}")
+        logger.debug("Removed environment variable PORT", port=port_val)
 
     on_start_logger(port)
     uvicorn.run(

--- a/agent_memory_server/vectorstore_adapter.py
+++ b/agent_memory_server/vectorstore_adapter.py
@@ -4,7 +4,6 @@ and LangChain VectorStore implementations, allowing for pluggable backends.
 """
 
 import hashlib
-import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -29,6 +28,7 @@ from agent_memory_server.filters import (
     Topics,
     UserId,
 )
+from agent_memory_server.logging import get_logger
 from agent_memory_server.models import (
     MemoryRecord,
     MemoryRecordResult,
@@ -36,7 +36,7 @@ from agent_memory_server.models import (
 )
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Type variable for VectorStore implementations
 VectorStoreType = TypeVar("VectorStoreType", bound=VectorStore)
@@ -832,7 +832,7 @@ class RedisVectorStoreAdapter(VectorStoreAdapter):
             score_threshold = 1.0 - distance_threshold
             search_kwargs["score_threshold"] = score_threshold
 
-        print("Search kwargs: ", search_kwargs)
+        logger.debug("Vector search parameters", **search_kwargs)
 
         search_results = (
             await self.vectorstore.asimilarity_search_with_relevance_scores(
@@ -840,7 +840,10 @@ class RedisVectorStoreAdapter(VectorStoreAdapter):
             )
         )
 
-        print("Search results: ", search_results)
+        logger.debug(
+            "Vector search results",
+            results=[(d.page_content, s) for d, s in search_results],
+        )
 
         # Convert results to MemoryRecordResult objects
         memory_results = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,17 @@
+import logging
+
+from agent_memory_server.config import get_config
+from agent_memory_server.logging import configure_logging
+
+
+def test_get_config_missing_file_logs_warning(caplog, monkeypatch):
+    configure_logging()
+    monkeypatch.setenv("REDIS_MEMORY_CONFIG", "missing_file.yaml")
+    with caplog.at_level(logging.WARNING):
+        config = get_config()
+    assert config == {}
+    assert any(
+        record.message == "Config file not found"
+        and record.config_file == "missing_file.yaml"
+        for record in caplog.records
+    )

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 
 from agent_memory_server.filters import Namespace, SessionId
+from agent_memory_server.logging import get_logger
 from agent_memory_server.long_term_memory import (
     compact_long_term_memories,
     count_long_term_memories,
@@ -25,6 +26,9 @@ from agent_memory_server.models import (
     MemoryRecordResults,
     MemoryTypeEnum,
 )
+
+
+logger = get_logger(__name__)
 
 
 # from agent_memory_server.utils.redis import ensure_search_index_exists  # Not used currently
@@ -952,17 +956,17 @@ class TestLongTermMemoryIntegration:
             )
 
             # If we get here without error, the test environment has proper schema
-            print("SUCCESS: No error occurred - Redis index supports user_id field")
+            logger.info("No error occurred - Redis index supports user_id field")
 
         except Exception as e:
-            print(f"ERROR REPRODUCED: {type(e).__name__}: {e}")
+            logger.info("ERROR REPRODUCED", error=f"{type(e).__name__}: {e}")
 
             # Check if this is the specific error we're trying to reproduce
             if "Unknown argument" in str(e) and "@user_id:" in str(e):
-                print("✅ Successfully reproduced the staging error!")
-                print("The Redis search index doesn't have user_id field indexed")
+                logger.info("Successfully reproduced the staging error!")
+                logger.info("The Redis search index doesn't have user_id field indexed")
             else:
-                print("❌ Different error occurred")
+                logger.info("Different error occurred")
 
             # Re-raise to see the full traceback
             raise

--- a/tests/test_memory_compaction.py
+++ b/tests/test_memory_compaction.py
@@ -4,12 +4,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent_memory_server.logging import get_logger
 from agent_memory_server.long_term_memory import (
     count_long_term_memories,
     generate_memory_hash,
     merge_memories_with_llm,
 )
 from agent_memory_server.models import MemoryRecord
+
+
+logger = get_logger(__name__)
 
 
 def test_generate_memory_hash():
@@ -196,11 +200,11 @@ async def test_hash_deduplication_integration(
 
     # Debug: Check what keys exist in Redis
     keys = await async_redis_client.keys("*")
-    print(f"🔍 Redis keys after indexing: {keys}")
+    logger.debug("Redis keys after indexing", keys=keys)
 
     # Debug: Check if we can find our specific namespace
     namespace_keys = [k for k in keys if b"hash_dedup_test_namespace" in k]
-    print(f"🔍 Keys with our namespace: {namespace_keys}")
+    logger.debug("Keys with our namespace", namespace_keys=namespace_keys)
 
     # Count memories in our specific namespace to avoid counting other test data
     remaining_before = await count_long_term_memories(


### PR DESCRIPTION
## Summary
- use `get_logger` in server modules and example
- log command execution in tagging script
- log warnings when config files are missing
- update tests to log instead of printing
- add test for log capture on missing config file

## Testing
- `ruff format tests/test_config.py agent_memory_server/config.py agent_memory_server/summarization.py agent_memory_server/vectorstore_adapter.py agent_memory_server/api.py agent_memory_server/main.py scripts/tag_and_push_client.py tests/test_memory_compaction.py tests/test_full_integration.py tests/test_long_term_memory.py examples/travel_agent.py`
- `ruff check tests/test_config.py agent_memory_server/config.py agent_memory_server/summarization.py agent_memory_server/vectorstore_adapter.py agent_memory_server/api.py agent_memory_server/main.py scripts/tag_and_push_client.py tests/test_memory_compaction.py tests/test_full_integration.py tests/test_long_term_memory.py examples/travel_agent.py --fix`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docket')*

------
https://chatgpt.com/codex/tasks/task_e_687100559b308332a00112b477ae20f2