### PR TITLE
Fix filter import structure

### DIFF
--- a/agent_memory_server/extraction.py
+++ b/agent_memory_server/extraction.py
@@ -8,7 +8,7 @@ from tenacity.stop import stop_after_attempt
 from transformers import AutoModelForTokenClassification, AutoTokenizer, pipeline
 
 from agent_memory_server.config import settings
-from agent_memory_server.filters import DiscreteMemoryExtracted
+from agent_memory_server.filters import DiscreteMemoryExtracted, MemoryType
 from agent_memory_server.llms import (
     AnthropicClientWrapper,
     OpenAIClientWrapper,
@@ -273,7 +273,6 @@ async def extract_discrete_memories(
 
     # Use vectorstore adapter to find messages that need discrete memory extraction
     # TODO: Sort out circular imports
-    from agent_memory_server.filters import MemoryType
     from agent_memory_server.long_term_memory import index_long_term_memories
     from agent_memory_server.vectorstore_factory import get_vectorstore_adapter
 

--- a/agent_memory_server/long_term_memory.py
+++ b/agent_memory_server/long_term_memory.py
@@ -430,22 +430,9 @@ async def compact_long_term_memories(
         # Get all memories using the vector store adapter
         try:
             # Convert filters to adapter format
-            namespace_filter = None
-            user_id_filter = None
-            session_id_filter = None
-
-            if namespace:
-                from agent_memory_server.filters import Namespace
-
-                namespace_filter = Namespace(eq=namespace)
-            if user_id:
-                from agent_memory_server.filters import UserId
-
-                user_id_filter = UserId(eq=user_id)
-            if session_id:
-                from agent_memory_server.filters import SessionId
-
-                session_id_filter = SessionId(eq=session_id)
+            namespace_filter = Namespace(eq=namespace) if namespace else None
+            user_id_filter = UserId(eq=user_id) if user_id else None
+            session_id_filter = SessionId(eq=session_id) if session_id else None
 
             # Use vectorstore adapter to get all memories
             adapter = await get_vectorstore_adapter()
@@ -1052,27 +1039,21 @@ async def deduplicate_by_id(
 
     # Use vectorstore adapter to search for memories with the same id
     # Build filter objects
-    namespace_filter = None
-    if namespace or memory.namespace:
-        from agent_memory_server.filters import Namespace
+    namespace_filter = (
+        Namespace(eq=namespace or memory.namespace)
+        if namespace or memory.namespace
+        else None
+    )
 
-        namespace_filter = Namespace(eq=namespace or memory.namespace)
+    user_id_filter = UserId(eq=user_id or memory.user_id) if user_id or memory.user_id else None
 
-    user_id_filter = None
-    if user_id or memory.user_id:
-        from agent_memory_server.filters import UserId
-
-        user_id_filter = UserId(eq=user_id or memory.user_id)
-
-    session_id_filter = None
-    if session_id or memory.session_id:
-        from agent_memory_server.filters import SessionId
-
-        session_id_filter = SessionId(eq=session_id or memory.session_id)
+    session_id_filter = (
+        SessionId(eq=session_id or memory.session_id)
+        if session_id or memory.session_id
+        else None
+    )
 
     # Create id filter
-    from agent_memory_server.filters import Id
-
     id_filter = Id(eq=memory.id)
 
     # Use vectorstore adapter to search for memories with the same id
@@ -1146,23 +1127,21 @@ async def deduplicate_by_semantic_search(
     adapter = await get_vectorstore_adapter()
 
     # Convert filters to adapter format
-    namespace_filter = None
-    user_id_filter = None
-    session_id_filter = None
-
-    # TODO: Refactor to avoid inline imports (fix circular imports)
-    if namespace or memory.namespace:
-        from agent_memory_server.filters import Namespace
-
-        namespace_filter = Namespace(eq=namespace or memory.namespace)
-    if user_id or memory.user_id:
-        from agent_memory_server.filters import UserId
-
-        user_id_filter = UserId(eq=user_id or memory.user_id)
-    if session_id or memory.session_id:
-        from agent_memory_server.filters import SessionId
-
-        session_id_filter = SessionId(eq=session_id or memory.session_id)
+    namespace_filter = (
+        Namespace(eq=namespace or memory.namespace)
+        if namespace or memory.namespace
+        else None
+    )
+    user_id_filter = (
+        UserId(eq=user_id or memory.user_id)
+        if user_id or memory.user_id
+        else None
+    )
+    session_id_filter = (
+        SessionId(eq=session_id or memory.session_id)
+        if session_id or memory.session_id
+        else None
+    )
 
     # Use the vectorstore adapter for semantic search
     # TODO: Paginate through results?

--- a/agent_memory_server/vectorstore_adapter.py
+++ b/agent_memory_server/vectorstore_adapter.py
@@ -593,8 +593,6 @@ class LangChainVectorStoreAdapter(VectorStoreAdapter):
         """Count memories in the vector store using LangChain."""
         try:
             # Convert basic filters to our filter objects, then to backend format
-            from agent_memory_server.filters import Namespace, SessionId, UserId
-
             namespace_filter = Namespace(eq=namespace) if namespace else None
             user_id_filter = UserId(eq=user_id) if user_id else None
             session_id_filter = SessionId(eq=session_id) if session_id else None
@@ -941,18 +939,12 @@ class RedisVectorStoreAdapter(VectorStoreAdapter):
             filters = []
 
             if namespace:
-                from agent_memory_server.filters import Namespace
-
                 namespace_filter = Namespace(eq=namespace).to_filter()
                 filters.append(namespace_filter)
             if user_id:
-                from agent_memory_server.filters import UserId
-
                 user_filter = UserId(eq=user_id).to_filter()
                 filters.append(user_filter)
             if session_id:
-                from agent_memory_server.filters import SessionId
-
                 session_filter = SessionId(eq=session_id).to_filter()
                 filters.append(session_filter)
 


### PR DESCRIPTION
## Summary
- remove inline filter imports from `long_term_memory`
- import `MemoryType` in `extraction` to avoid dynamic import
- drop runtime imports from `vectorstore_adapter`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docket')*

------
https://chatgpt.com/codex/tasks/task_e_687100544dd48332b78b08aeb9aa0901