### PR TITLE
Expose BERTopic model path in settings

### DIFF
--- a/agent_memory_server/config.py
+++ b/agent_memory_server/config.py
@@ -81,6 +81,7 @@ class Settings(BaseSettings):
     # If using BERTopic, use a supported model, such as
     # "MaartenGr/BERTopic_Wikipedia"
     topic_model: str = "gpt-4o-mini"
+    topic_model_path: str = "MaartenGr/BERTopic_Wikipedia"
     enable_topic_extraction: bool = True
     top_k_topics: int = 3
 

--- a/agent_memory_server/extraction.py
+++ b/agent_memory_server/extraction.py
@@ -44,9 +44,8 @@ def get_topic_model() -> "BERTopic":
 
     global _topic_model
     if _topic_model is None:
-        # TODO: Expose this as a config option
         _topic_model = BERTopic.load(
-            settings.topic_model, embedding_model="all-MiniLM-L6-v2"
+            settings.topic_model_path, embedding_model="all-MiniLM-L6-v2"
         )
     return _topic_model  # type: ignore
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,14 @@ The names of the settings map directly to an environment variable, so for
 example, you can set the `openai_api_key` setting with the `OPENAI_API_KEY`
 environment variable.
 
+### Topic Modeling
+
+If you enable BERTopic based extraction (`topic_model_source="BERTopic"`),
+the server loads the model specified by `topic_model_path`. Set the
+`TOPIC_MODEL_PATH` environment variable to point to your BERTopic model
+directory or HuggingFace repository. By default it uses
+`MaartenGr/BERTopic_Wikipedia`.
+
 ## Running the Background Task Worker
 
 The Redis Memory Server uses Docket for background task management. You can run a worker instance like this:

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -567,7 +567,7 @@ class TestTopicExtractionIntegration:
         settings.enable_topic_extraction = True
         settings.enable_ner = True
         settings.topic_model_source = "BERTopic"
-        settings.topic_model = "MaartenGr/BERTopic_Wikipedia"
+        settings.topic_model_path = "MaartenGr/BERTopic_Wikipedia"
 
         sample_text = (
             "OpenAI and Google are leading companies in artificial intelligence."


### PR DESCRIPTION
## Summary
- add `topic_model_path` to Settings
- load BERTopic using the path from config
- document `TOPIC_MODEL_PATH` in configuration guide
- update extraction tests to use the new setting

## Testing
- `uv run pre-commit run --files agent_memory_server/config.py agent_memory_server/extraction.py tests/test_extraction.py docs/configuration.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docket')*

------
https://chatgpt.com/codex/tasks/task_e_6871004d387883328e4059fcf15ffd56